### PR TITLE
Replace zeroes with next value in CSV

### DIFF
--- a/process_reports.sh
+++ b/process_reports.sh
@@ -49,4 +49,35 @@ for date in $dates; do
     echo "$date,$plugins_without_jenkinsfile,$plugins_with_java8,$plugins_without_java_versions" >> $OUTPUT_FILE
 done
 
+# Read the CSV file into an array
+mapfile -t csv_lines < "$OUTPUT_FILE"
+
+# Replace zeroes with the next non-zero value
+for ((i=1; i<${#csv_lines[@]}; i++)); do
+    IFS=',' read -r date plugins_without_jenkinsfile plugins_with_java8 plugins_without_java_versions <<< "${csv_lines[i]}"
+    
+    if [[ $plugins_without_jenkinsfile -eq 0 ]]; then
+        plugins_without_jenkinsfile=$last_plugins_without_jenkinsfile
+    else
+        last_plugins_without_jenkinsfile=$plugins_without_jenkinsfile
+    fi
+    
+    if [[ $plugins_with_java8 -eq 0 ]]; then
+        plugins_with_java8=$last_plugins_with_java8
+    else
+        last_plugins_with_java8=$plugins_with_java8
+    fi
+    
+    if [[ $plugins_without_java_versions -eq 0 ]]; then
+        plugins_without_java_versions=$last_plugins_without_java_versions
+    else
+        last_plugins_without_java_versions=$plugins_without_java_versions
+    fi
+    
+    csv_lines[i]="$date,$plugins_without_jenkinsfile,$plugins_with_java8,$plugins_without_java_versions"
+done
+
+# Write the updated lines back to the CSV file
+printf "%s\n" "${csv_lines[@]}" > "$OUTPUT_FILE"
+
 echo "Processing complete. Results saved to $OUTPUT_FILE"

--- a/process_reports.sh
+++ b/process_reports.sh
@@ -1,83 +1,104 @@
 #!/bin/bash
 
-# Define the directory containing the reports
-REPORTS_DIR="reports"
+    # Define the directory containing the reports
+    REPORTS_DIR="reports"
 
-# Output file to store the results
-OUTPUT_FILE="plugin_evolution.csv"
+    # Output file to store the results
+    OUTPUT_FILE="plugin_evolution.csv"
 
-# Initialize the output file with headers
-echo "Date,Plugins_Without_Jenkinsfile,Plugins_With_Java8,Plugins_Without_Java_Versions" > $OUTPUT_FILE
+    # Initialize the output file with headers
+    echo "Date,Plugins_Without_Jenkinsfile,Plugins_With_Java8,Plugins_Without_Java_Versions" > $OUTPUT_FILE
 
-# Extract unique dates from filenames
-dates=$(find "$REPORTS_DIR" -type f -name "*.txt" -o -name "*.csv" | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}' | sort | uniq)
+    # Extract unique dates from filenames
+    dates=$(find "$REPORTS_DIR" -type f -name "*.txt" -o -name "*.csv" | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}' | sort | uniq)
 
-# Initialize last known values
-last_plugins_without_jenkinsfile=0
-last_plugins_with_java8=0
-last_plugins_without_java_versions=0
+    # Initialize last known values
+    last_plugins_without_jenkinsfile=0
+    last_plugins_with_java8=0
+    last_plugins_without_java_versions=0
 
-# Loop through each unique date
-for date in $dates; do
-    # Initialize counts for this date
-    plugins_without_jenkinsfile=$last_plugins_without_jenkinsfile
-    plugins_with_java8=$last_plugins_with_java8
-    plugins_without_java_versions=$last_plugins_without_java_versions
-
-    # Find and count "plugins_no_jenkinsfile" files
-    no_jenkinsfile_file=$(find $REPORTS_DIR -type f -name "plugins_no_jenkinsfile_$date.txt" | head -n 1)
-    if [[ -n "$no_jenkinsfile_file" && -f "$no_jenkinsfile_file" ]]; then
-        plugins_without_jenkinsfile=$(wc -l < "$no_jenkinsfile_file")
-        last_plugins_without_jenkinsfile=$plugins_without_jenkinsfile
-    fi
-
-    # Find and count "plugins_old_java" files
-    old_java_file=$(find $REPORTS_DIR -type f -name "plugins_old_java_$date.txt" | head -n 1)
-    if [[ -n "$old_java_file" && -f "$old_java_file" ]]; then
-        plugins_with_java8=$(wc -l < "$old_java_file")
-        last_plugins_with_java8=$plugins_with_java8
-    fi
-
-    # Find and count "plugins_without_java_versions" files
-    without_java_versions_file=$(find $REPORTS_DIR -type f -name "plugins_without_java_versions_$date.csv" | head -n 1)
-    if [[ -n "$without_java_versions_file" && -f "$without_java_versions_file" ]]; then
-        plugins_without_java_versions=$(wc -l < "$without_java_versions_file")
-        last_plugins_without_java_versions=$plugins_without_java_versions
-    fi
-
-    # Append the results to the output file
-    echo "$date,$plugins_without_jenkinsfile,$plugins_with_java8,$plugins_without_java_versions" >> $OUTPUT_FILE
-done
-
-# Read the CSV file into an array
-mapfile -t csv_lines < "$OUTPUT_FILE"
-
-# Replace zeroes with the next non-zero value
-for ((i=1; i<${#csv_lines[@]}; i++)); do
-    IFS=',' read -r date plugins_without_jenkinsfile plugins_with_java8 plugins_without_java_versions <<< "${csv_lines[i]}"
-    
-    if [[ $plugins_without_jenkinsfile -eq 0 ]]; then
+    # Loop through each unique date
+    for date in $dates; do
+        # Initialize counts for this date
         plugins_without_jenkinsfile=$last_plugins_without_jenkinsfile
-    else
-        last_plugins_without_jenkinsfile=$plugins_without_jenkinsfile
-    fi
-    
-    if [[ $plugins_with_java8 -eq 0 ]]; then
         plugins_with_java8=$last_plugins_with_java8
-    else
-        last_plugins_with_java8=$plugins_with_java8
-    fi
-    
-    if [[ $plugins_without_java_versions -eq 0 ]]; then
         plugins_without_java_versions=$last_plugins_without_java_versions
+
+        # Find and count "plugins_no_jenkinsfile" files
+        no_jenkinsfile_file=$(find $REPORTS_DIR -type f -name "plugins_no_jenkinsfile_$date.txt" | head -n 1)
+        if [[ -n "$no_jenkinsfile_file" && -f "$no_jenkinsfile_file" ]]; then
+            plugins_without_jenkinsfile=$(wc -l < "$no_jenkinsfile_file")
+            last_plugins_without_jenkinsfile=$plugins_without_jenkinsfile
+        fi
+
+        # Find and count "plugins_old_java" files
+        old_java_file=$(find $REPORTS_DIR -type f -name "plugins_old_java_$date.txt" | head -n 1)
+        if [[ -n "$old_java_file" && -f "$old_java_file" ]]; then
+            plugins_with_java8=$(wc -l < "$old_java_file")
+            last_plugins_with_java8=$plugins_with_java8
+        fi
+
+        # Find and count "plugins_without_java_versions" files
+        without_java_versions_file=$(find $REPORTS_DIR -type f -name "plugins_without_java_versions_$date.csv" | head -n 1)
+        if [[ -n "$without_java_versions_file" && -f "$without_java_versions_file" ]]; then
+            plugins_without_java_versions=$(wc -l < "$without_java_versions_file")
+            last_plugins_without_java_versions=$plugins_without_java_versions
+        fi
+
+        # Append the results to the output file
+        echo "$date,$plugins_without_jenkinsfile,$plugins_with_java8,$plugins_without_java_versions" >> $OUTPUT_FILE
+    done
+
+    # Check if the output CSV file exists and is non-empty
+    if [[ -s "$OUTPUT_FILE" ]]; then
+      # Read the CSV file into an array
+      mapfile -t csv_lines < "$OUTPUT_FILE"
     else
-        last_plugins_without_java_versions=$plugins_without_java_versions
+      echo "Error: $OUTPUT_FILE does not exist or is empty."
+      exit 1
     fi
-    
-    csv_lines[i]="$date,$plugins_without_jenkinsfile,$plugins_with_java8,$plugins_without_java_versions"
-done
 
-# Write the updated lines back to the CSV file
-printf "%s\n" "${csv_lines[@]}" > "$OUTPUT_FILE"
+    # Replace zeroes with the next non-zero value
+    for ((i=1; i<${#csv_lines[@]}; i++)); do
+        IFS=',' read -r date plugins_without_jenkinsfile plugins_with_java8 plugins_without_java_versions <<< "${csv_lines[i]}"
 
-echo "Processing complete. Results saved to $OUTPUT_FILE"
+        if [[ $plugins_without_jenkinsfile -eq 0 ]]; then
+            for ((j=i+1; j<${#csv_lines[@]}; j++)); do
+                IFS=',' read -r _ next_plugins_without_jenkinsfile _ <<< "${csv_lines[j]}"
+                if [[ $next_plugins_without_jenkinsfile -ne 0 ]]; then
+                    plugins_without_jenkinsfile=$next_plugins_without_jenkinsfile
+                    break
+                fi
+            done
+        fi
+
+        if [[ $plugins_with_java8 -eq 0 ]]; then
+            for ((j=i+1; j<${#csv_lines[@]}; j++)); do
+                IFS=',' read -r _ _ next_plugins_with_java8 <<< "${csv_lines[j]}"
+                if [[ $next_plugins_with_java8 -ne 0 ]]; then
+                    plugins_with_java8=$next_plugins_with_java8
+                    break
+                fi
+            done
+        fi
+
+        if [[ $plugins_without_java_versions -eq 0 ]]; then
+            for ((j=i+1; j<${#csv_lines[@]}; j++)); do
+                IFS=',' read -r _ _ _ next_plugins_without_java_versions <<< "${csv_lines[j]}"
+                if [[ $next_plugins_without_java_versions -ne 0 ]]; then
+                    plugins_without_java_versions=$next_plugins_without_java_versions
+                    break
+                fi
+            done
+        fi
+
+        csv_lines[i]="$date,$plugins_without_jenkinsfile,$plugins_with_java8,$plugins_without_java_versions"
+    done
+
+    # Create a backup of the original CSV file
+    cp "$OUTPUT_FILE" "${OUTPUT_FILE}.bak"
+
+    # Write the updated lines back to the CSV file
+    printf "%s\n" "${csv_lines[@]}" > "$OUTPUT_FILE"
+
+    echo "Processing complete. Results saved to $OUTPUT_FILE"

--- a/process_reports.sh
+++ b/process_reports.sh
@@ -1,104 +1,104 @@
 #!/bin/bash
 
-    # Define the directory containing the reports
-    REPORTS_DIR="reports"
+        # Define the directory containing the reports
+        REPORTS_DIR="reports"
 
-    # Output file to store the results
-    OUTPUT_FILE="plugin_evolution.csv"
+        # Output file to store the results
+        OUTPUT_FILE="plugin_evolution.csv"
 
-    # Initialize the output file with headers
-    echo "Date,Plugins_Without_Jenkinsfile,Plugins_With_Java8,Plugins_Without_Java_Versions" > $OUTPUT_FILE
+        # Initialize the output file with headers
+        echo "Date,Plugins_Without_Jenkinsfile,Plugins_With_Java8,Plugins_Without_Java_Versions" > $OUTPUT_FILE
 
-    # Extract unique dates from filenames
-    dates=$(find "$REPORTS_DIR" -type f -name "*.txt" -o -name "*.csv" | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}' | sort | uniq)
+        # Extract unique dates from filenames
+        dates=$(find "$REPORTS_DIR" -type f -name "*.txt" -o -name "*.csv" | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}' | sort | uniq)
 
-    # Initialize last known values
-    last_plugins_without_jenkinsfile=0
-    last_plugins_with_java8=0
-    last_plugins_without_java_versions=0
+        # Initialize last known values
+        last_plugins_without_jenkinsfile=0
+        last_plugins_with_java8=0
+        last_plugins_without_java_versions=0
 
-    # Loop through each unique date
-    for date in $dates; do
-        # Initialize counts for this date
-        plugins_without_jenkinsfile=$last_plugins_without_jenkinsfile
-        plugins_with_java8=$last_plugins_with_java8
-        plugins_without_java_versions=$last_plugins_without_java_versions
+        # Loop through each unique date
+        for date in $dates; do
+            # Initialize counts for this date
+            plugins_without_jenkinsfile=$last_plugins_without_jenkinsfile
+            plugins_with_java8=$last_plugins_with_java8
+            plugins_without_java_versions=$last_plugins_without_java_versions
 
-        # Find and count "plugins_no_jenkinsfile" files
-        no_jenkinsfile_file=$(find $REPORTS_DIR -type f -name "plugins_no_jenkinsfile_$date.txt" | head -n 1)
-        if [[ -n "$no_jenkinsfile_file" && -f "$no_jenkinsfile_file" ]]; then
-            plugins_without_jenkinsfile=$(wc -l < "$no_jenkinsfile_file")
-            last_plugins_without_jenkinsfile=$plugins_without_jenkinsfile
+            # Find and count "plugins_no_jenkinsfile" files
+            no_jenkinsfile_file=$(find $REPORTS_DIR -type f -name "plugins_no_jenkinsfile_$date.txt" | head -n 1)
+            if [[ -n "$no_jenkinsfile_file" && -f "$no_jenkinsfile_file" ]]; then
+                plugins_without_jenkinsfile=$(wc -l < "$no_jenkinsfile_file")
+                last_plugins_without_jenkinsfile=$plugins_without_jenkinsfile
+            fi
+
+            # Find and count "plugins_old_java" files
+            old_java_file=$(find $REPORTS_DIR -type f -name "plugins_old_java_$date.txt" | head -n 1)
+            if [[ -n "$old_java_file" && -f "$old_java_file" ]]; then
+                plugins_with_java8=$(wc -l < "$old_java_file")
+                last_plugins_with_java8=$plugins_with_java8
+            fi
+
+            # Find and count "plugins_without_java_versions" files
+            without_java_versions_file=$(find $REPORTS_DIR -type f -name "plugins_without_java_versions_$date.csv" | head -n 1)
+            if [[ -n "$without_java_versions_file" && -f "$without_java_versions_file" ]]; then
+                plugins_without_java_versions=$(wc -l < "$without_java_versions_file")
+                last_plugins_without_java_versions=$plugins_without_java_versions
+            fi
+
+            # Append the results to the output file
+            echo "$date,$plugins_without_jenkinsfile,$plugins_with_java8,$plugins_without_java_versions" >> $OUTPUT_FILE
+        done
+
+        # Check if the output CSV file exists and is non-empty
+        if [[ -s "$OUTPUT_FILE" ]]; then
+          # Read the CSV file into an array
+          mapfile -t csv_lines < "$OUTPUT_FILE"
+        else
+          echo "Error: $OUTPUT_FILE does not exist or is empty."
+          exit 1
         fi
 
-        # Find and count "plugins_old_java" files
-        old_java_file=$(find $REPORTS_DIR -type f -name "plugins_old_java_$date.txt" | head -n 1)
-        if [[ -n "$old_java_file" && -f "$old_java_file" ]]; then
-            plugins_with_java8=$(wc -l < "$old_java_file")
-            last_plugins_with_java8=$plugins_with_java8
-        fi
+        # Replace zeroes with the next non-zero value
+        for ((i=1; i<${#csv_lines[@]}; i++)); do
+            IFS=',' read -r date plugins_without_jenkinsfile plugins_with_java8 plugins_without_java_versions <<< "${csv_lines[i]}"
 
-        # Find and count "plugins_without_java_versions" files
-        without_java_versions_file=$(find $REPORTS_DIR -type f -name "plugins_without_java_versions_$date.csv" | head -n 1)
-        if [[ -n "$without_java_versions_file" && -f "$without_java_versions_file" ]]; then
-            plugins_without_java_versions=$(wc -l < "$without_java_versions_file")
-            last_plugins_without_java_versions=$plugins_without_java_versions
-        fi
+            if [[ $plugins_without_jenkinsfile -eq 0 ]]; then
+                for ((j=i+1; j<${#csv_lines[@]}; j++)); do
+                    IFS=',' read -r _ next_plugins_without_jenkinsfile _ _ <<< "${csv_lines[j]}"
+                    if [[ $next_plugins_without_jenkinsfile -ne 0 ]]; then
+                        plugins_without_jenkinsfile=$next_plugins_without_jenkinsfile
+                        break
+                    fi
+                done
+            fi
 
-        # Append the results to the output file
-        echo "$date,$plugins_without_jenkinsfile,$plugins_with_java8,$plugins_without_java_versions" >> $OUTPUT_FILE
-    done
+            if [[ $plugins_with_java8 -eq 0 ]]; then
+                for ((j=i+1; j<${#csv_lines[@]}; j++)); do
+                    IFS=',' read -r _ _ next_plugins_with_java8 _ <<< "${csv_lines[j]}"
+                    if [[ $next_plugins_with_java8 -ne 0 ]]; then
+                        plugins_with_java8=$next_plugins_with_java8
+                        break
+                    fi
+                done
+            fi
 
-    # Check if the output CSV file exists and is non-empty
-    if [[ -s "$OUTPUT_FILE" ]]; then
-      # Read the CSV file into an array
-      mapfile -t csv_lines < "$OUTPUT_FILE"
-    else
-      echo "Error: $OUTPUT_FILE does not exist or is empty."
-      exit 1
-    fi
+            if [[ $plugins_without_java_versions -eq 0 ]]; then
+                for ((j=i+1; j<${#csv_lines[@]}; j++)); do
+                    IFS=',' read -r _ _ _ next_plugins_without_java_versions <<< "${csv_lines[j]}"
+                    if [[ $next_plugins_without_java_versions -ne 0 ]]; then
+                        plugins_without_java_versions=$next_plugins_without_java_versions
+                        break
+                    fi
+                done
+            fi
 
-    # Replace zeroes with the next non-zero value
-    for ((i=1; i<${#csv_lines[@]}; i++)); do
-        IFS=',' read -r date plugins_without_jenkinsfile plugins_with_java8 plugins_without_java_versions <<< "${csv_lines[i]}"
+            csv_lines[i]="$date,$plugins_without_jenkinsfile,$plugins_with_java8,$plugins_without_java_versions"
+        done
 
-        if [[ $plugins_without_jenkinsfile -eq 0 ]]; then
-            for ((j=i+1; j<${#csv_lines[@]}; j++)); do
-                IFS=',' read -r _ next_plugins_without_jenkinsfile _ <<< "${csv_lines[j]}"
-                if [[ $next_plugins_without_jenkinsfile -ne 0 ]]; then
-                    plugins_without_jenkinsfile=$next_plugins_without_jenkinsfile
-                    break
-                fi
-            done
-        fi
+        # Create a backup of the original CSV file
+        cp "$OUTPUT_FILE" "${OUTPUT_FILE}.bak"
 
-        if [[ $plugins_with_java8 -eq 0 ]]; then
-            for ((j=i+1; j<${#csv_lines[@]}; j++)); do
-                IFS=',' read -r _ _ next_plugins_with_java8 <<< "${csv_lines[j]}"
-                if [[ $next_plugins_with_java8 -ne 0 ]]; then
-                    plugins_with_java8=$next_plugins_with_java8
-                    break
-                fi
-            done
-        fi
+        # Write the updated lines back to the CSV file
+        printf "%s\n" "${csv_lines[@]}" > "$OUTPUT_FILE"
 
-        if [[ $plugins_without_java_versions -eq 0 ]]; then
-            for ((j=i+1; j<${#csv_lines[@]}; j++)); do
-                IFS=',' read -r _ _ _ next_plugins_without_java_versions <<< "${csv_lines[j]}"
-                if [[ $next_plugins_without_java_versions -ne 0 ]]; then
-                    plugins_without_java_versions=$next_plugins_without_java_versions
-                    break
-                fi
-            done
-        fi
-
-        csv_lines[i]="$date,$plugins_without_jenkinsfile,$plugins_with_java8,$plugins_without_java_versions"
-    done
-
-    # Create a backup of the original CSV file
-    cp "$OUTPUT_FILE" "${OUTPUT_FILE}.bak"
-
-    # Write the updated lines back to the CSV file
-    printf "%s\n" "${csv_lines[@]}" > "$OUTPUT_FILE"
-
-    echo "Processing complete. Results saved to $OUTPUT_FILE"
+        echo "Processing complete. Results saved to $OUTPUT_FILE"


### PR DESCRIPTION
Fixes #63

Add logic to replace zeroes with the next non-zero value in `process_reports.sh`.

* **Read CSV file**: Read the CSV file into an array.
* **Replace zeroes**: Add logic to replace zeroes with the next non-zero value for each column.
* **Update CSV file**: Write the updated lines back to the CSV file.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/gounthar/jdk8-removal/pull/64?shareId=42e9ff06-9da1-4d53-a9a1-ab5a497a4a27).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced CSV report generation now replaces zero entries with the most recent valid counts, ensuring more consistent and accurate reporting data. Users benefit from improved data continuity and clearer insights in generated reports, leading to enhanced reliability of outputs. These improvements help significantly minimize discrepancies caused by missing count values.
  - Added a verification step to ensure the output CSV file exists and is non-empty before processing, improving error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->