### PR TITLE
Use `NA` instead of the first significant number, and omit plot for `NA`

### DIFF
--- a/plot-jenkins-stats.py
+++ b/plot-jenkins-stats.py
@@ -17,6 +17,17 @@ def create_plugins_evolution_plot(input_csv, output_svg):
     # Read the CSV file
     df = pd.read_csv(input_csv)
 
+    # Replace 'MISSING' values with NaN
+    df.replace('MISSING', pd.NA, inplace=True)
+
+    # Drop rows with NaN values
+    df.dropna(inplace=True)
+
+    # Check if the DataFrame is empty
+    if df.empty:
+        print("Warning: The CSV file is empty or contains only 'MISSING' values.")
+        return
+
     # Convert dates to datetime
     df['Date'] = pd.to_datetime(df['Date'])
 

--- a/process_reports.sh
+++ b/process_reports.sh
@@ -109,63 +109,27 @@ for ((i=1; i<${#csv_lines[@]}; i++)); do
     IFS=',' read -r date plugins_without_jenkinsfile plugins_with_java8 plugins_without_java_versions plugins_using_jdk11 plugins_depends_on_java_8 plugins_depends_on_java_11 <<< "${csv_lines[i]}"
 
     if [[ $plugins_without_jenkinsfile -eq 0 ]]; then
-        for ((j=i+1; j<${#csv_lines[@]}; j++)); do
-            IFS=',' read -r _ next_plugins_without_jenkinsfile _ _ _ _ _ <<< "${csv_lines[j]}"
-            if [[ $next_plugins_without_jenkinsfile -ne 0 ]]; then
-                plugins_without_jenkinsfile=$next_plugins_without_jenkinsfile
-                break
-            fi
-        done
+        plugins_without_jenkinsfile="MISSING"
     fi
 
     if [[ $plugins_with_java8 -eq 0 ]]; then
-        for ((j=i+1; j<${#csv_lines[@]}; j++)); do
-            IFS=',' read -r _ _ next_plugins_with_java8 _ _ _ _ <<< "${csv_lines[j]}"
-            if [[ $next_plugins_with_java8 -ne 0 ]]; then
-                plugins_with_java8=$next_plugins_with_java8
-                break
-            fi
-        done
+        plugins_with_java8="MISSING"
     fi
 
     if [[ $plugins_without_java_versions -eq 0 ]]; then
-        for ((j=i+1; j<${#csv_lines[@]}; j++)); do
-            IFS=',' read -r _ _ _ next_plugins_without_java_versions _ _ _ <<< "${csv_lines[j]}"
-            if [[ $next_plugins_without_java_versions -ne 0 ]]; then
-                plugins_without_java_versions=$next_plugins_without_java_versions
-                break
-            fi
-        done
+        plugins_without_java_versions="MISSING"
     fi
 
     if [[ $plugins_using_jdk11 -eq 0 ]]; then
-        for ((j=i+1; j<${#csv_lines[@]}; j++)); do
-            IFS=',' read -r _ _ _ _ next_plugins_using_jdk11 _ _ <<< "${csv_lines[j]}"
-            if [[ $next_plugins_using_jdk11 -ne 0 ]]; then
-                plugins_using_jdk11=$next_plugins_using_jdk11
-                break
-            fi
-        done
+        plugins_using_jdk11="MISSING"
     fi
 
     if [[ $plugins_depends_on_java_8 -eq 0 ]]; then
-        for ((j=i+1; j<${#csv_lines[@]}; j++)); do
-            IFS=',' read -r _ _ _ _ _ next_plugins_depends_on_java_8 _ <<< "${csv_lines[j]}"
-            if [[ $next_plugins_depends_on_java_8 -ne 0 ]]; then
-                plugins_depends_on_java_8=$next_plugins_depends_on_java_8
-                break
-            fi
-        done
+        plugins_depends_on_java_8="MISSING"
     fi
 
     if [[ $plugins_depends_on_java_11 -eq 0 ]]; then
-        for ((j=i+1; j<${#csv_lines[@]}; j++)); do
-            IFS=',' read -r _ _ _ _ _ _ next_plugins_depends_on_java_11 <<< "${csv_lines[j]}"
-            if [[ $next_plugins_depends_on_java_11 -ne 0 ]]; then
-                plugins_depends_on_java_11=$next_plugins_depends_on_java_11
-                break
-            fi
-        done
+        plugins_depends_on_java_11="MISSING"
     fi
 
     csv_lines[i]="$date,$plugins_without_jenkinsfile,$plugins_with_java8,$plugins_without_java_versions,$plugins_using_jdk11,$plugins_depends_on_java_8,$plugins_depends_on_java_11"


### PR DESCRIPTION
Fixes #85

Update `process_reports.sh` and `plot-jenkins-stats.py` to handle missing data using `MISSING` and `NaN`.

* **process_reports.sh**
  - Replace zeroes with `MISSING` for missing data in various metrics.
  - Handle the `MISSING` placeholder appropriately during CSV processing.

* **plot-jenkins-stats.py**
  - Replace `MISSING` values with `NaN` using pandas.
  - Drop rows with `NaN` values before plotting.
  - Add a check to ensure the CSV file is not empty or does not contain only `NaN` values before plotting.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/gounthar/jdk8-removal/pull/86?shareId=867ce2f0-fe33-48f7-b6a3-814f31c0e3eb).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved data handling for plotting, ensuring only valid data is used and users are alerted if input data is insufficient.
	- Updated report processing to display a clear "MISSING" indicator for absent values, providing more consistent and understandable results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->