### PR TITLE
Remove the 'depends on java 8' graph generation

### DIFF
--- a/plot-jenkins-stats.py
+++ b/plot-jenkins-stats.py
@@ -8,7 +8,6 @@ PLOT_COLORS = {
     'with_java8': '#2ecc71',
     'without_java_versions': '#3498db',
     'using_jdk11': '#ff5733',
-    'depends_on_java_8': '#8e44ad',
     'depends_on_java_11': '#f39c12'
 }
 
@@ -35,8 +34,6 @@ def create_plugins_evolution_plot(input_csv, output_svg):
              marker='^', label='Without Java Versions', color=PLOT_COLORS['without_java_versions'])
     plt.plot(df['Date'], df['Plugins_Using_JDK11'],
              marker='d', label='Using JDK 11', color=PLOT_COLORS['using_jdk11'])
-    plt.plot(df['Date'], df['Plugins_Depends_On_Java_8'],
-             marker='*', label='Depends On Java 8', color=PLOT_COLORS['depends_on_java_8'])
     plt.plot(df['Date'], df['Plugins_Depends_On_Java_11'],
              marker='x', label='Depends On Java 11', color=PLOT_COLORS['depends_on_java_11'])
 


### PR DESCRIPTION
Fixes #96

Remove the graph generation for the 'depends on java 8' data line in the `plot-jenkins-stats.py` script.

* Remove the 'depends on java 8' entry from the `PLOT_COLORS` dictionary.
* Remove the line that plots the 'depends on java 8' data.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/gounthar/jdk8-removal/pull/97?shareId=fcd5678f-c4e1-462f-a915-eef676d0a822).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the Jenkins statistics chart by removing the segment that represented plugins dependent on an older Java version, ensuring the visualization now highlights only the supported Java platform. This change streamlines the display and simplifies data interpretation for end users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->