### PR TITLE
fix: improve JDK 25 validation step messaging

### DIFF
--- a/.github/workflows/jdk25-tracking.yml
+++ b/.github/workflows/jdk25-tracking.yml
@@ -124,13 +124,27 @@ jobs:
           chmod +x validate_jdk25_detection.py
 
           REPORT_FILE="reports/jdk25_tracking_with_prs_${{ steps.date.outputs.date }}.json"
+          MANUAL_CSV="Java_25_Compatibility_check.csv"
 
-          if [ -f "$REPORT_FILE" ] && [ -f "Java_25_Compatibility_check.csv" ]; then
-            echo "Running validation..."
-            ./validate_jdk25_detection.py "$REPORT_FILE" || true
-          else
-            echo "Skipping validation (missing files)"
+          echo "Checking validation prerequisites..."
+          echo "  Report file: $REPORT_FILE"
+          echo "  Manual CSV: $MANUAL_CSV"
+
+          if [ ! -f "$REPORT_FILE" ]; then
+            echo "⚠️ Report file not found: $REPORT_FILE"
+            echo "Validation requires the automated tracking results."
+            exit 0
           fi
+
+          if [ ! -f "$MANUAL_CSV" ]; then
+            echo "ℹ️ Skipping validation - manual CSV not available in CI"
+            echo "The validation script compares automated results against manual tracking."
+            echo "To run validation locally, export the manual spreadsheet as CSV first."
+            exit 0
+          fi
+
+          echo "✓ All prerequisites met, running validation..."
+          ./validate_jdk25_detection.py "$REPORT_FILE" || true
 
       - name: Generate summary
         if: always()


### PR DESCRIPTION
## Summary

Improves the validation step messaging in the JDK 25 tracking workflow to make it clearer why validation is skipped in CI.

## Problem

The validation step was showing a generic "Skipping validation (missing files)" message without explaining which files were missing or why. This caused confusion about whether something was broken.

## Solution

Enhanced the validation step to:
- ✅ Log validation prerequisites clearly (report file and manual CSV)
- ✅ Explain why validation is skipped in CI (manual CSV not available)
- ✅ Provide instructions for running validation locally
- ✅ Use informative emojis for better readability
- ✅ Exit gracefully with status 0 when prerequisites aren't met

## Context

The validation script (`validate_jdk25_detection.py`) compares automated detection results against a manually maintained spreadsheet (`Java_25_Compatibility_check.csv`). This manual CSV is not part of the repository and won't be available in CI runs, so validation being skipped is **expected behavior** for automated workflows.

## Example Output

**Before:**
```
Skipping validation (missing files)
```

**After:**
```
Checking validation prerequisites...
  Report file: reports/jdk25_tracking_with_prs_2025-10-09.json
  Manual CSV: Java_25_Compatibility_check.csv
ℹ️ Skipping validation - manual CSV not available in CI
The validation script compares automated results against manual tracking.
To run validation locally, export the manual spreadsheet as CSV first.
```

## Testing

- Workflow logic verified locally
- No breaking changes to existing behavior
- Validation step still runs successfully when both files exist

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI validation with explicit prerequisite checks and clearer messages when required inputs are missing.
  * Validation only runs when all required artifacts are present; otherwise, the job exits early with informative notes.
  * Preserves prior behavior when validation executes (no change to outcome handling).
  * No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->