### PR TITLE
feat: add manual trigger to Update Plugins Evolution Plot workflow

### DIFF
--- a/.github/workflows/github-workflow.yml
+++ b/.github/workflows/github-workflow.yml
@@ -5,9 +5,10 @@ on:
     paths:
       - 'reports/**'  # Trigger when reports directory changes
     branches:
-      - main  # Allow manual trigger on the main branch
+      - main
   schedule:
     - cron: '59 6 * * *'  # Run daily at 06:59 UTC
+  workflow_dispatch:  # Allow manual execution of the workflow
 
 jobs:
   update-plot:


### PR DESCRIPTION
## Summary
Adds `workflow_dispatch` trigger to the "Update Plugins Evolution Plot" workflow, allowing manual execution from the GitHub Actions UI.

## Changes
- ✅ Added `workflow_dispatch` trigger
- ✅ Cleaned up misleading comment that was on the `branches` line

## Current Triggers (After This Change)
1. **Push to reports/**  - Automatic trigger when report files change
2. **Daily schedule** - Runs at 06:59 UTC every day
3. **Manual (NEW)** - Can now be triggered manually via GitHub Actions UI

## How to Use Manual Trigger
After merging this PR, you can manually run the workflow:

1. Go to **Actions** tab in GitHub
2. Select **"Update Plugins Evolution Plot"** workflow
3. Click **"Run workflow"** button
4. Select the branch (usually `main`)
5. Click **"Run workflow"**

## Testing
No runtime changes - only adds a new trigger method. The workflow logic remains unchanged.

## Benefits
- Flexibility to regenerate plots on-demand
- Useful when testing changes or when automatic triggers don't cover a specific use case
- No impact on existing automatic triggers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Updated CI workflow to allow manual runs from the Actions tab, in addition to existing push and scheduled triggers. This enables ad-hoc validation and faster iteration without requiring commits.
  * No user-facing changes; functionality remains unchanged for end users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->