### PR TITLE
fix: handle unbound variables in check-jdk-versions.sh

### DIFF
--- a/check-jdk-versions.sh
+++ b/check-jdk-versions.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 
 
 # Enable debug mode if DEBUG_MODE is set to true
-if [ "$DEBUG_MODE" = "true" ]; then
+if [ "${DEBUG_MODE:-false}" = "true" ]; then
   set -x
 fi
 
@@ -28,7 +28,7 @@ output_csv="reports/jdk_versions_tracking_$current_date.csv"
 output_json="reports/jdk_versions_tracking_$current_date.json"
 
 # Set up log file if not already defined
-if [ -z "$LOG_FILE" ]; then
+if [ -z "${LOG_FILE:-}" ]; then
   export LOG_FILE="logs/jdk_versions_tracking_$current_date.log"
 fi
 


### PR DESCRIPTION
## Summary
Fixes unbound variable errors that caused the JDK Versions Tracking workflow to fail immediately on first run.

## Problem
The workflow failed with:
```
./check-jdk-versions.sh: line 31: LOG_FILE: unbound variable
```

With `set -u` (error on unset variables), the script failed when checking undefined variables.

## Changes
- Line 13: Changed `$DEBUG_MODE` to `${DEBUG_MODE:-false}` - provides default value when DEBUG_MODE is not set
- Line 31: Changed `$LOG_FILE` to `${LOG_FILE:-}` - safely checks if LOG_FILE is unset without triggering error

## Test Plan
- [x] Manually tested the fix logic
- [ ] Will trigger workflow manually to verify fix works

## Related
- Fixes workflow run #18431258511 that failed after merging PR #560

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Prevents unintended debug tracing when debug mode isn’t explicitly enabled.
  - Avoids errors when a log file path isn’t provided by using a sensible default.
  - Improves handling of empty or unset configuration values for more reliable execution.
- Chores
  - Hardened environment variable handling to reduce unbound-variable issues and improve script robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->