### PR TITLE
fix: prevent set -e exit on arithmetic expression in check-jdk-versions.sh

### DIFF
--- a/check-jdk-versions.sh
+++ b/check-jdk-versions.sh
@@ -232,7 +232,7 @@ while IFS=',' read -r plugin_name popularity; do
     # Extract repository path (e.g., "jenkinsci/script-security-plugin")
     repo_path=$(echo "$repo_url" | sed 's|https://github.com/||' | sed 's|\.git$||')
     echo "$repo_path" >> "$repos_list"
-    ((plugin_count++))
+    ((plugin_count++)) || true  # Prevent set -e exit when count is 0
   else
     debug "No repository found for plugin: $plugin_name"
   fi


### PR DESCRIPTION
## Summary
Fixes arithmetic expression issue that caused the script to exit immediately when incrementing plugin_count from 0.

## Problem
After fixing the unbound variable errors in PR #561, the workflow still failed at line 235:

```bash
((plugin_count++))
```

With `set -e` (exit on error), the expression `((0++))` evaluates to 0, which bash treats as a failure exit code. This is a classic bash gotcha with arithmetic expressions in strict mode.

## Changes
- Line 235: Added `|| true` to `((plugin_count++))` to prevent `set -e` from exiting the script
- This allows the counter to increment safely even when starting from 0

## Test Plan
- [x] Identified the issue from workflow logs
- [ ] Will trigger workflow manually to verify fix works

## Related
- Continues fixes from PR #561
- Fixes workflow run #18431331462 that failed after initial fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of the JDK version checking script by preventing premature termination on non-critical increments during plugin processing. This ensures the script continues scanning all repositories/plugins under strict error settings, resulting in more consistent and complete results. Users should see fewer unexpected failures and more stable execution when running the check across multiple projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->