### PR TITLE
fix: use explicit file list in GitGuardian config

### DIFF
--- a/.gitguardian.yaml
+++ b/.gitguardian.yaml
@@ -5,13 +5,21 @@ version: 2
 
 # Paths to ignore for secret detection
 # These are data files that frequently trigger false positives
+# Using explicit file names instead of wildcards to avoid accidentally
+# ignoring real secrets in the root directory
 paths-ignore:
   - reports/**/*
-  - "*.json"
-  - "*.csv"
-  - "*.txt"
   - plugins.json
-  - all-plugins.csv
+  - found_prs.json
+  - jenkins_prs.json
+  - report.json
+  - plugin_evolution.csv
+  - recipes-to-apply.csv
+  - top-250-plugins.csv
+  - depends_on_java_8.txt
+  - depends_on_java_11.txt
+  - manual_jdk25_plugins.txt
+  - plugins_jdk11_main_*.txt
 
 # Ignore specific patterns that are not secrets
 # These are common patterns in Jenkins plugin data that look like secrets but aren't


### PR DESCRIPTION
## Summary
- Replace broad wildcards (`*.json`, `*.csv`, `*.txt`) with explicit list of known data files
- Remove redundant entries (plugins.json, all-plugins.csv) that were already covered by wildcards
- Add comment explaining why explicit names are preferred over wildcards

## Motivation
Addresses security concern raised by @gemini-code-assist in PR #568.

Using wildcards in the root directory is too broad and could accidentally ignore real secrets if they're committed with common file extensions. By explicitly listing only the known data files, we maintain security while still preventing false positives on legitimate data files.

## Changes
- `.gitguardian.yaml`: Replace wildcards with explicit file list including:
  - JSON files: plugins.json, found_prs.json, jenkins_prs.json, report.json
  - CSV files: plugin_evolution.csv, recipes-to-apply.csv, top-250-plugins.csv
  - TXT files: depends_on_java_*.txt, manual_jdk25_plugins.txt, plugins_jdk11_main_*.txt

## Related
- Fixes review comment in PR #568
- Reference: https://github.com/gounthar/jdk8-removal/pull/568#discussion_r2424763454

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined secret scanning configuration to use explicit file ignores, reducing accidental omissions and improving clarity.
  * Added targeted ignore patterns for known non-secret Jenkins URLs and plugin paths to cut false positives.

* **Documentation**
  * Included guidance within the configuration on using explicit file names in ignore lists to prevent skipping real secrets and to make intent clearer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->