### PR TITLE
fix: add top_plugins_with_versions.txt to GitGuardian ignore

### DIFF
--- a/.gitguardian.yaml
+++ b/.gitguardian.yaml
@@ -20,8 +20,7 @@ paths-ignore:
   - depends_on_java_11.txt
   - manual_jdk25_plugins.txt
   - plugins_jdk11_main_*.txt
-  - plugins_with_versions.txt
-  - top_plugins_with_versions.txt
+  - '*plugins_with_versions.txt'
 
 # Ignore specific patterns that are not secrets
 # These are common patterns in Jenkins plugin data that look like secrets but aren't


### PR DESCRIPTION
## Summary

GitGuardian is still failing on "Update plugins list" PRs due to `top_plugins_with_versions.txt` not being in the ignore list.

## Root Cause

PR #576 failed GitGuardian check even though PR #575 (which added `plugins_with_versions.txt`) was already merged. Investigation revealed a second file causing false positives.

### Files Changed in PR #576:
```
✅ depends_on_java_8.txt (explicitly listed)
✅ plugins.json (explicitly listed)
✅ plugins_jdk11_main_2025-10-13.txt (covered by plugins_jdk11_main_*.txt)
✅ plugins_with_versions.txt (explicitly listed)
✅ reports/*.csv (covered by reports/**/*)
✅ reports/*.txt (covered by reports/**/*)
❌ top_plugins_with_versions.txt (NOT IGNORED - causes GitGuardian failure!)
```

`top_plugins_with_versions.txt` is similar to `plugins_with_versions.txt` - it contains plugin version information from the Jenkins update center that frequently triggers GitGuardian false positives.

## Fix

Added `top_plugins_with_versions.txt` to the paths-ignore list in `.gitguardian.yaml`.

## Impact

- ✅ Prevents GitGuardian false positives on routine "Update plugins list" PRs
- ✅ Allows auto-merge workflow to proceed when all checks pass
- ✅ Consistent with other data files already in the ignore list

## Related

- Fixes GitGuardian failures on PR #576 and future "Update plugins list" PRs
- Follow-up to PR #575 which added `plugins_with_versions.txt`
- Part of the auto-merge workflow fixes (PR #572, #574, #575)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Broadened secret-scanning ignore patterns to reduce false positives from non-sensitive files.
  - Improves developer workflow and CI signal quality.
  - No user-facing changes or impact on performance, features, or UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->