### PR TITLE
fix: quote wildcard patterns in GitGuardian config

### DIFF
--- a/.gitguardian.yaml
+++ b/.gitguardian.yaml
@@ -8,7 +8,7 @@ version: 2
 # Using explicit file names instead of wildcards to avoid accidentally
 # ignoring real secrets in the root directory
 paths-ignore:
-  - reports/**/*
+  - 'reports/**'
   - plugins.json
   - found_prs.json
   - jenkins_prs.json
@@ -19,7 +19,7 @@ paths-ignore:
   - depends_on_java_8.txt
   - depends_on_java_11.txt
   - manual_jdk25_plugins.txt
-  - plugins_jdk11_main_*.txt
+  - 'plugins_jdk11_main_*.txt'
   - '*plugins_with_versions.txt'
 
 # Ignore specific patterns that are not secrets


### PR DESCRIPTION
## Summary

GitGuardian is still failing on PR #578 despite having ignore rules for the flagged files. The issue is that **wildcard patterns need to be quoted** in YAML for GitGuardian to parse them correctly.

## Root Cause

GitGuardian flagged these files in PR #578:
```
❌ reports/depends_on_java_8_2025-10-13.txt (multiple Generic High Entropy Secret detections)
❌ plugins_jdk11_main_2025-10-13.txt (Generic High Entropy Secret detections)
```

These files **should** have been covered by existing ignore rules:
- `reports/**/*` should cover `reports/depends_on_java_8_2025-10-13.txt`
- `plugins_jdk11_main_*.txt` should cover `plugins_jdk11_main_2025-10-13.txt`

But they weren't! The problem is that GitGuardian's YAML parser requires wildcard patterns to be quoted.

## Fix

Changed unquoted wildcard patterns to quoted:

```yaml
# Before
paths-ignore:
  - reports/**/*           # ❌ Unquoted - not parsed correctly
  - plugins_jdk11_main_*.txt  # ❌ Unquoted - not parsed correctly

# After  
paths-ignore:
  - 'reports/**'           # ✅ Quoted - will be parsed correctly
  - 'plugins_jdk11_main_*.txt'  # ✅ Quoted - will be parsed correctly
```

Also simplified `reports/**/*` to `reports/**` (both mean "all files under reports recursively").

## Impact

- ✅ GitGuardian will correctly ignore files in reports/ directory
- ✅ GitGuardian will correctly ignore plugins_jdk11_main_*.txt files
- ✅ Allows auto-merge workflow to proceed when all checks pass
- ✅ Consistent quoting style for all wildcard patterns

## Related

- Fixes GitGuardian failures on PR #578
- Follow-up to PR #575, #577 (previous GitGuardian fixes)
- Part of auto-merge workflow fixes (PR #572, #574, #575, #577)

## Testing

Once merged, PR #578 should be re-run or a new "Update plugins list" PR created to verify GitGuardian passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration patterns to use quoted strings for more reliable parsing in security scans.
  * Improves consistency of configuration interpretation across environments.
  * No user-facing changes or functional impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->