### PR TITLE
fix: use proper version 2 syntax for GitGuardian config

### DIFF
--- a/.gitguardian.yaml
+++ b/.gitguardian.yaml
@@ -9,8 +9,8 @@ secret:
   # These are data files that frequently trigger false positives
   # Using gitignore-style glob patterns
   ignored_paths:
-    # Reports directory - all files
-    - 'reports/**'
+    # Reports directory - all files (anchored to root)
+    - '/reports/**'
     # Root level JSON files (anchored with / to match only at root)
     - '/plugins.json'
     - '/found_prs.json'


### PR DESCRIPTION
## Problem

GitGuardian was still failing on automated PRs (#580, #581) despite having comprehensive ignore patterns because the configuration was using **version 1 syntax with version 2 declaration**.

## Root Cause

The `.gitguardian.yaml` file declared `version: 2` but used v1 field names:
- ❌ `paths-ignore:` (v1 syntax)
- ❌ `matches-ignore:` (v1 syntax)

Version 2 requires:
- ✅ `secret.ignored_paths:` (v2 syntax)
- ✅ `secret.ignored_matches:` (v2 syntax)

This caused GitGuardian to completely ignore all the ignore patterns, resulting in failures on every automated PR.

## Solution

Updated `.gitguardian.yaml` to use proper version 2 syntax with nested structure under `secret:` field.

## Testing

This fix should resolve GitGuardian failures on:
- PR #580 (Update plugins list 2025-10-13)
- PR #581 (Update plugins list 2025-10-14)
- Future automated PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Migrated secret-scanning configuration to a Version 2 structure with nested keys.
  * Introduced secret.ignored_paths (glob and root-anchored patterns) and secret.ignored_matches (entries supporting name and regex).
  * Converted several repository patterns to regex and preserved one non-anchored pattern.
  * Removed the previous top-level paths-ignore and matches-ignore keys for a cleaner layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->