### PR TITLE
fix: remove redundant echo in grep -c command

### DIFF
--- a/check-jdk25-open-prs.sh
+++ b/check-jdk25-open-prs.sh
@@ -405,8 +405,8 @@ if [ -n "$previous_json" ] && [ -f "$previous_json" ]; then
     fi
   done < "$current_prs"
 
-  new_count=$(echo "$new_prs" | grep -c . 2>/dev/null)
-  closed_count=$(echo "$closed_prs" | grep -c . 2>/dev/null)
+  new_count=$(grep -c . <<< "$new_prs")
+  closed_count=$(grep -c . <<< "$closed_prs")
 
   info ""
   info "Changes since $previous_date:"


### PR DESCRIPTION
## Summary

Fixes the "integer expression required" error in `check-jdk25-open-prs.sh` that was causing GitHub Actions workflow to fail.

## Problem

When `grep -c .` returns 0, it exits with success code 0, causing the `|| echo 0` fallback to also execute. This results in the value `"0\n0"` which breaks integer comparison on line 419:

```bash
./check-jdk25-open-prs.sh: line 419: [: 0
0: integer expression expected
```

## Solution

Since `grep -c` always succeeds and outputs a count (even if 0), the `|| echo 0` fallback is unnecessary and causes the bug.

Changed from:
```bash
new_count=$(echo "$new_prs" | grep -c . 2>/dev/null || echo 0)
```

To:
```bash
new_count=$(echo "$new_prs" | grep -c . 2>/dev/null)
```

## Test Plan

Tested locally with empty input:
```bash
test_empty=""
new_count=$(echo "$test_empty" | grep -c .)
echo "Count is: [$new_count]"
# Output: Count is: [0]
```

## Related

Fixes: https://github.com/gounthar/jdk8-removal/actions/runs/18831902136

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Simplified a build/validation script by streamlining its handling of empty outputs, relying on native command behavior instead of explicit fallback logic. No functional or user-facing behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->