### PR TITLE
fix: prevent auto-merge circular dependency

### DIFF
--- a/.github/workflows/auto-merge-update-plugins.yml
+++ b/.github/workflows/auto-merge-update-plugins.yml
@@ -105,10 +105,10 @@ jobs:
             # Get check status
             CHECK_DATA=$(gh pr view "$PR_NUMBER" --json statusCheckRollup --repo ${{ github.repository }})
 
-            # Count checks (excluding GitGuardian which is optional)
-            total_checks=$(echo "$CHECK_DATA" | jq '[.statusCheckRollup[] | select(.name != "GitGuardian Security Checks")] | length')
-            pending_checks=$(echo "$CHECK_DATA" | jq '[.statusCheckRollup[] | select(.name != "GitGuardian Security Checks") | select(.status == "IN_PROGRESS" or .status == "QUEUED" or (.state // "" | test("PENDING|EXPECTED")))] | length')
-            failed_checks=$(echo "$CHECK_DATA" | jq '[.statusCheckRollup[] | select(.name != "GitGuardian Security Checks") | select(.conclusion == "FAILURE" or (.state // "" | test("FAILURE|ERROR")))] | length')
+            # Count checks (excluding optional GitGuardian and the auto-merge check itself to avoid circular dependency)
+            total_checks=$(echo "$CHECK_DATA" | jq '[.statusCheckRollup[] | select(.name != "GitGuardian Security Checks" and .name != "auto-merge")] | length')
+            pending_checks=$(echo "$CHECK_DATA" | jq '[.statusCheckRollup[] | select(.name != "GitGuardian Security Checks" and .name != "auto-merge") | select(.status == "IN_PROGRESS" or .status == "QUEUED" or (.state // "" | test("PENDING|EXPECTED")))] | length')
+            failed_checks=$(echo "$CHECK_DATA" | jq '[.statusCheckRollup[] | select(.name != "GitGuardian Security Checks" and .name != "auto-merge") | select(.conclusion == "FAILURE" or (.state // "" | test("FAILURE|ERROR")))] | length')
 
             echo "Checks: $total_checks total, $pending_checks pending, $failed_checks failed"
 
@@ -154,13 +154,13 @@ jobs:
             exit 1
           fi
 
-          # Double-check all status checks are passing (with null safety, excluding optional GitGuardian)
+          # Double-check all status checks are passing (with null safety, excluding optional GitGuardian and auto-merge itself)
           CHECK_DATA=$(gh pr view "$PR_NUMBER" --json statusCheckRollup --repo ${{ github.repository }})
-          failed_checks=$(echo "$CHECK_DATA" | jq '[(.statusCheckRollup // [])[] | select(.name != "GitGuardian Security Checks") | select((.conclusion // "") == "FAILURE" or (.state // "" | test("FAILURE|ERROR")))] | length')
+          failed_checks=$(echo "$CHECK_DATA" | jq '[(.statusCheckRollup // [])[] | select(.name != "GitGuardian Security Checks" and .name != "auto-merge") | select((.conclusion // "") == "FAILURE" or (.state // "" | test("FAILURE|ERROR")))] | length')
 
           if [ "$failed_checks" -gt 0 ]; then
             echo "❌ Found $failed_checks failed check(s), aborting merge"
-            echo "$CHECK_DATA" | jq -r '(.statusCheckRollup // [])[] | select(.name != "GitGuardian Security Checks") | select((.conclusion // "") == "FAILURE" or (.state // "" | test("FAILURE|ERROR"))) | "  - \(.name): \(.conclusion // .state)"'
+            echo "$CHECK_DATA" | jq -r '(.statusCheckRollup // [])[] | select(.name != "GitGuardian Security Checks" and .name != "auto-merge") | select((.conclusion // "") == "FAILURE" or (.state // "" | test("FAILURE|ERROR"))) | "  - \(.name): \(.conclusion // .state)"'
             exit 1
           fi
 


### PR DESCRIPTION
## Summary
- Fixed circular dependency where auto-merge workflow waits for itself to complete
- Excluded "auto-merge" check from status check monitoring
- Maintains exclusion of GitGuardian checks

## Problem
In PR #607, we fixed the GitGuardian blocking issue, but introduced a new problem: the auto-merge workflow waits for ALL checks to pass, including itself. This creates a deadlock where:
1. auto-merge runs and waits for all checks
2. auto-merge is one of the checks
3. auto-merge never completes because it's waiting for itself

## Solution
Updated the workflow to exclude itself from the checks it monitors, similar to how we exclude GitGuardian. Now the workflow only waits for:
- CodeQL
- Analyze (actions, go, python)
- Any other checks (but not auto-merge or GitGuardian)

## Test Plan
- [x] Modify workflow to exclude auto-merge from its own monitoring
- [ ] Merge this PR
- [ ] Re-run auto-merge for PR #606 to verify it completes successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD automation workflows to refine status check handling and verification processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->